### PR TITLE
Restart usage report buffer consumption thread when it dies

### DIFF
--- a/lib/graphql-hive.rb
+++ b/lib/graphql-hive.rb
@@ -148,6 +148,10 @@ module GraphQL
       @usage_reporter.on_exit
     end
 
+    def on_start
+      @usage_reporter.on_start
+    end
+
     private
 
     def initialize_options!(options)


### PR DESCRIPTION
fixes https://github.com/charlypoly/graphql-ruby-hive/issues/9

When a process does a unix fork (which the puma web server does when running in its ["clustered mode"](https://github.com/puma/puma/tree/f323d129bc165fdafbede8392fee94c8d03f5d66#clustered-mode)), threads are not copied over.

`GraphQL::Hive::UsageReporter` uses a thread to read / send usage-report data, so we need to restart it if it dies