### PR TITLE
Add "on_start" hook to revive thread after a fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,39 @@ If you only want to use the operations monitoring, replace the `reporting` optio
 
 <br/>
 
+## 3. (Optional) Configure Lifecycle Hooks
+
+Calling these hooks are situational - it's likely that you may not need to call
+them at all!
+
+### `on_start`
+
+Call this hook if you are running `GraphQL::Hive` in a process that becomes
+`forked` - for example a puma web server in its ["clustered
+mode"](https://github.com/puma/puma/tree/6d8b728b42a61bcf3c1e4c698c9165a45e6071e8#clustered-mode),
+
+```ruby
+# config/puma.rb
+preload_app!
+
+on_worker_boot do
+  GraphQL::Hive.instance.on_start
+end
+```
+
+### `on_exit`
+
+If your GraphQL API process is shut down non-gracefully but has a shutdown hook
+to call into (like `puma` does when running in its clustered mode), call
+`on_worker_exit`
+
+```ruby
+on_worker_shutdown do
+  GraphQL::Hive.instance.on_exit
+end
+```
+
+<br />
 
 **You are all set! 🚀**
 
@@ -74,7 +107,7 @@ When deploying or starting up your GraphQL API, `graphql-hive` will immediately:
 
 <br/>
 
-## 3. See how your GraphQL API is operating
+## 4. See how your GraphQL API is operating
 
 You should now see operations information (RPM, error rate, queries performed) on your [GraphQL Hive dashboard](https://app.graphql-hive.com/):
 
@@ -86,7 +119,7 @@ You should now see operations information (RPM, error rate, queries performed) o
 <br/>
 
 
-## 4. Going further: use the Hive Github app
+## 5. Going further: use the Hive Github app
 
 Stay on top of your GraphQL Schema changes by installing the Hive Github Application and enabling Slack notifications about breaking changes:
 

--- a/lib/graphql-hive.rb
+++ b/lib/graphql-hive.rb
@@ -148,6 +148,11 @@ module GraphQL
       @usage_reporter.on_exit
     end
 
+    def on_start
+      options[:logger]&.info('on_start called')
+      @usage_reporter.on_start
+    end
+
     private
 
     def initialize_options!(options)

--- a/lib/graphql-hive.rb
+++ b/lib/graphql-hive.rb
@@ -149,7 +149,6 @@ module GraphQL
     end
 
     def on_start
-      options[:logger]&.info('on_start called')
       @usage_reporter.on_start
     end
 

--- a/lib/graphql-hive/usage_reporter.rb
+++ b/lib/graphql-hive/usage_reporter.rb
@@ -66,6 +66,7 @@ module GraphQL
             end
           end
           unless buffer.size.zero?
+            @options[:logger].debug('shuting down with buffer, sending!')
             process_operations(buffer)
           end
         end

--- a/lib/graphql-hive/usage_reporter.rb
+++ b/lib/graphql-hive/usage_reporter.rb
@@ -27,6 +27,31 @@ module GraphQL
 
         @options_mutex = Mutex.new
         @queue = Queue.new
+
+        start_thread
+      end
+
+      def add_operation(operation)
+        @queue.push(operation)
+      end
+
+      def on_exit
+        @queue.close
+        @thread.join
+      end
+
+      def on_start
+        start_thread
+      end
+
+      private
+
+      def start_thread
+        if @thread && @thread.alive?
+          @options[:logger].warn("Tried to start operations flushing thread but it was already alive")
+          return
+        end
+
         @thread = Thread.new do
           buffer = []
           while (operation = @queue.pop(false))
@@ -41,22 +66,10 @@ module GraphQL
             end
           end
           unless buffer.size.zero?
-            @options[:logger].debug('shuting down with buffer, sending!')
             process_operations(buffer)
           end
         end
       end
-
-      def add_operation(operation)
-        @queue.push(operation)
-      end
-
-      def on_exit
-        @queue.close
-        @thread.join
-      end
-
-      private
 
       def process_operations(operations)
         report = {


### PR DESCRIPTION
Closes https://github.com/charlypoly/graphql-ruby-hive/issues/9

Adds a `on_start` thread which restarts the thread that flushes the queue of sampled operations.

