### PR TITLE
support input object fields

### DIFF
--- a/lib/graphql-hive/analyzer.rb
+++ b/lib/graphql-hive/analyzer.rb
@@ -15,10 +15,12 @@ module GraphQL
       end
 
       def on_leave_argument(node, parent, visitor)
-        @used_fields.add([visitor.parent_type_definition.graphql_name, parent.name, node.name].join('.'))
+        if parent.respond_to?(:name)
+          @used_fields.add([visitor.parent_type_definition.graphql_name, parent.name, node.name].join('.'))
+        end
 
         arg_type = visitor.argument_definition.type.unwrap
-        arg_type_kind = visitor.argument_definition.type.unwrap.kind
+        arg_type_kind = arg_type.kind
         if arg_type_kind.input_object?
           @used_fields.add(arg_type.graphql_name)
           arg_type.arguments.each do |arg|

--- a/lib/graphql-hive/analyzer.rb
+++ b/lib/graphql-hive/analyzer.rb
@@ -30,9 +30,6 @@ module GraphQL
         elsif arg_type.kind.enum?
           collect_enum_values(node, arg_type)
         end
-      rescue StandardError => e
-        require 'pry'
-        binding.pry
       end
 
       attr_reader :used_fields
@@ -71,11 +68,7 @@ module GraphQL
             @used_fields.add(make_id(enum_type.graphql_name, n))
           end
         else
-          begin
-            @used_fields.add(make_id(enum_type.graphql_name, node.value.name))
-          rescue StandardError => e
-            binding.pry
-          end
+          @used_fields.add(make_id(enum_type.graphql_name, node.value.name))
         end
       end
 

--- a/lib/graphql-hive/analyzer.rb
+++ b/lib/graphql-hive/analyzer.rb
@@ -11,18 +11,18 @@ module GraphQL
 
       def on_enter_field(node, _parent, visitor)
         @used_fields.add(visitor.parent_type_definition.graphql_name)
-        @used_fields.add([visitor.parent_type_definition.graphql_name, node.name].join('.'))
+        @used_fields.add(make_id(visitor.parent_type_definition.graphql_name, node.name))
       end
 
-      # Visitor also calls 'on_enter_argument' when visiting explicit input object fields
+      # Visitor also calls 'on_enter_argument' when visiting input object fields in arguments
       def on_enter_argument(node, parent, visitor)
         arg_type = visitor.argument_definition.type.unwrap
         @used_fields.add(arg_type.graphql_name)
 
-        # collect argument path
+        # collect field argument path
         # input object fields won't have a "parent.name" method available
         if parent.respond_to?(:name)
-          @used_fields.add([visitor.parent_type_definition.graphql_name, parent.name, node.name].join('.'))
+          @used_fields.add(make_id(visitor.parent_type_definition.graphql_name, parent.name, node.name))
         end
 
         if arg_type.kind.input_object?
@@ -30,6 +30,9 @@ module GraphQL
         elsif arg_type.kind.enum?
           collect_enum_values(node, arg_type)
         end
+      rescue StandardError => e
+        require 'pry'
+        binding.pry
       end
 
       attr_reader :used_fields
@@ -43,11 +46,15 @@ module GraphQL
       def collect_input_object_fields(node, input_type)
         if node.value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
           input_type.all_argument_definitions.map(&:graphql_name).each do |n|
-            @used_fields.add([input_type.graphql_name, n].join('.'))
+            @used_fields.add(make_id(input_type.graphql_name, n))
+          end
+        elsif node.value.is_a?(Array)
+          node.value.flat_map(&:arguments).map(&:name).each do |n|
+            @used_fields.add(make_id(input_type.graphql_name, n))
           end
         else
           node.value.arguments.map(&:name).each do |n|
-            @used_fields.add([input_type.graphql_name, n].join('.'))
+            @used_fields.add(make_id(input_type.graphql_name, n))
           end
         end
       end
@@ -55,11 +62,23 @@ module GraphQL
       def collect_enum_values(node, enum_type)
         if node.value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
           enum_type.values.values.map(&:graphql_name).each do |n|
-            @used_fields.add([enum_type.graphql_name, n].join('.'))
+            @used_fields.add(make_id(enum_type.graphql_name, n))
+          end
+        elsif node.value.is_a?(Array)
+          node.value.map(&:name).each do |n|
+            @used_fields.add(make_id(enum_type.graphql_name, n))
           end
         else
-          @used_fields.add([enum_type.graphql_name, node.value.name].join('.'))
+          begin
+            @used_fields.add(make_id(enum_type.graphql_name, node.value.name))
+          rescue StandardError => e
+            binding.pry
+          end
         end
+      end
+
+      def make_id(*tokens)
+        tokens.join('.')
       end
     end
   end

--- a/lib/graphql-hive/analyzer.rb
+++ b/lib/graphql-hive/analyzer.rb
@@ -44,11 +44,12 @@ module GraphQL
       private
 
       def collect_input_object_fields(node, input_type)
-        if node.value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
+        case node.value
+        when GraphQL::Language::Nodes::VariableIdentifier
           input_type.all_argument_definitions.map(&:graphql_name).each do |n|
             @used_fields.add(make_id(input_type.graphql_name, n))
           end
-        elsif node.value.is_a?(Array)
+        when Array
           node.value.flat_map(&:arguments).map(&:name).each do |n|
             @used_fields.add(make_id(input_type.graphql_name, n))
           end
@@ -60,11 +61,12 @@ module GraphQL
       end
 
       def collect_enum_values(node, enum_type)
-        if node.value.is_a?(GraphQL::Language::Nodes::VariableIdentifier)
+        case node.value
+        when GraphQL::Language::Nodes::VariableIdentifier
           enum_type.values.values.map(&:graphql_name).each do |n|
             @used_fields.add(make_id(enum_type.graphql_name, n))
           end
-        elsif node.value.is_a?(Array)
+        when Array
           node.value.map(&:name).each do |n|
             @used_fields.add(make_id(enum_type.graphql_name, n))
           end

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -144,9 +144,13 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
     end
 
     it 'collects used enumn values' do
-      puts used_fields
       expect(used_fields).to include(
         'ProjectType.FEDERATION'
+      )
+      expect(used_fields).not_to include(
+        'ProjectType.STITCHING',
+        'ProjectType.SINGLE',
+        'ProjectType.CUSTOM',
       )
     end
   end
@@ -165,7 +169,6 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
     it 'collects fields of specified input objects' do
       expect(used_fields).to include(
         'FilterInput',
-        'FilterInput.order'
         'FilterInput.pagination',
         'FilterInput.type',
         'PaginationInput',
@@ -175,6 +178,7 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
       )
 
       expect(used_fields).not_to include(
+        'FilterInput.order',
         'PaginationInput.offset',
       )
     end
@@ -196,12 +200,36 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
         'Pagination',
         'Pagination.limit',
         'PaginationInput.offset',
-        'FilterInput.type'
+        'FilterInput.type',
         'FilterInput.pagination',
       )
 
       expect(used_fields).not_to include(
         'FilterInput.order',
+      )
+    end
+  end
+
+  context 'with query containing enum value in nested input object' do
+    let(:query_string) do
+      %|
+        query getProjects($type: ProjectType!, $limit: Int) {
+          projects(filter: { pagination: { limit: $limit }, type: $type, order: ASC }) {
+            limit: Int
+            offset: Int
+            id
+          }
+        }
+      |
+    end
+
+    it 'collects the enum value' do
+      expect(used_fields).to include(
+        'OrderDirection.ASC'
+      )
+
+      expect(used_fields).not_to include(
+        'OrderDirection.DESC',
       )
     end
   end

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -132,13 +132,15 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
   end
 
   context 'with enum value in argument' do
-    let(:query_string) {%|
+    let(:query_string) do
+      %|
       query getProjects($type: ProjectType!) {
         projectsByType(type: $type) {
           id
         }
       }
-    |}
+    |
+    end
 
     it 'collects all values of that enum type' do
       expect(used_fields).to include(
@@ -151,13 +153,15 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
   end
 
   context 'with enum value hardcoded into the query' do
-    let(:query_string) {%|
+    let(:query_string) do
+      %|
       query getProjects {
         projectsByType(type: FEDERATION) {
           id
         }
       }
-    |}
+    |
+    end
 
     it 'collects used enumn values' do
       expect(used_fields).to include(
@@ -172,13 +176,15 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
   end
 
   context 'with only some input object fields used' do
-    let(:query_string) {%|
+    let(:query_string) do
+      %|
       query getProjects($limit: Int!, $type: ProjectType!) {
         projects(filter: { pagination: { limit: $limit }, type: $type }) {
           id
         }
       }
-    |}
+    |
+    end
 
     it 'collects fields of specified input objects' do
       expect(used_fields).to include(
@@ -198,13 +204,15 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
   end
 
   context 'with query containining both input object variable as well as explicit input object fields' do
-    let(:query_string) {%|
+    let(:query_string) do
+      %|
       query getProjects($type: ProjectType!, $pagination: PaginationInput) {
         projects(filter: { pagination: $pagination, type: $type }) {
           id
         }
       }
-    |}
+    |
+    end
 
     it 'collects all fields of input object variable, but only specific fields for the other input object type' do
       expect(used_fields).to include(
@@ -222,7 +230,8 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
   end
 
   context 'with query containing enum value in nested input object' do
-    let(:query_string) {%|
+    let(:query_string) do
+      %|
       query getProjects($type: ProjectType!, $limit: Int) {
         projects(filter: {
           pagination: {
@@ -237,7 +246,8 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
           id
         }
       }
-    |}
+    |
+    end
 
     it 'collects the enum value' do
       expect(used_fields).to include(

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
       expect(used_fields).not_to include(
         'ProjectType.STITCHING',
         'ProjectType.SINGLE',
-        'ProjectType.CUSTOM',
+        'ProjectType.CUSTOM'
       )
     end
   end
@@ -173,13 +173,12 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
         'FilterInput.type',
         'PaginationInput',
         'PaginationInput.limit',
-        'ProjectType.type',
-        'Query.projects.filter',
+        'Query.projects.filter'
       )
 
       expect(used_fields).not_to include(
         'FilterInput.order',
-        'PaginationInput.offset',
+        'PaginationInput.offset'
       )
     end
   end
@@ -201,11 +200,11 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
         'Pagination.limit',
         'PaginationInput.offset',
         'FilterInput.type',
-        'FilterInput.pagination',
+        'FilterInput.pagination'
       )
 
       expect(used_fields).not_to include(
-        'FilterInput.order',
+        'FilterInput.order'
       )
     end
   end
@@ -215,8 +214,6 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
       %|
         query getProjects($type: ProjectType!, $limit: Int) {
           projects(filter: { pagination: { limit: $limit }, type: $type, order: ASC }) {
-            limit: Int
-            offset: Int
             id
           }
         }
@@ -229,7 +226,7 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
       )
 
       expect(used_fields).not_to include(
-        'OrderDirection.DESC',
+        'OrderDirection.DESC'
       )
     end
   end

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -253,10 +253,10 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
 
     it 'collects fields from the input values' do
       expect(used_fields).to include(
-        'ProjectOrderByInput.field',
+        'ProjectOrderByInput.field'
       )
       expect(used_fields).to_not include(
-        'ProjectOrderByInput.direction',
+        'ProjectOrderByInput.direction'
       )
     end
   end
@@ -340,12 +340,12 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
     it 'collects the used enum values' do
       expect(used_fields).to include(
         'ProjectType.STITCHING',
-        'ProjectType.FEDERATION',
+        'ProjectType.FEDERATION'
       )
 
       expect(used_fields).not_to include(
         'ProjectType.SINGLE',
-        'ProjectType.CUSTOM',
+        'ProjectType.CUSTOM'
       )
     end
   end

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -102,7 +102,6 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
   end
 
   it 'collects used fields' do
-    puts used_fields
     expect(used_fields).to include(
       'DeleteProjectPayload',
       'DeleteProjectPayload.selector',
@@ -196,8 +195,8 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
 
     it 'collects all fields of the non-destructured input object and only fields of the explicitly destructured input object' do
       expect(used_fields).to include(
-        'Pagination',
-        'Pagination.limit',
+        'PaginationInput',
+        'PaginationInput.limit',
         'PaginationInput.offset',
         'FilterInput.type',
         'FilterInput.pagination'
@@ -213,7 +212,16 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
     let(:query_string) do
       %|
         query getProjects($type: ProjectType!, $limit: Int) {
-          projects(filter: { pagination: { limit: $limit }, type: $type, order: ASC }) {
+          projects(filter: {
+            pagination: {
+              limit: $limit
+            },
+            type: $type,
+            order: {
+              field: "test",
+              direction: ASC,
+            }
+          }) {
             id
           }
         }

--- a/spec/graphql/graphql-hive/analyzer_spec.rb
+++ b/spec/graphql/graphql-hive/analyzer_spec.rb
@@ -3,56 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe 'GraphQL::Hive::Analyzer' do
-  let(:schema) do
-    GraphQL::Schema.from_definition(%|
-    """
-    A blog post
-    """
-    type Post {
-      id: ID!
-      title: String!
-      truncatedPreview: String!
-    }
-
-    """
-    Query Post arguments
-    """
-    input PostInput {
-      id: ID!
-    }
-
-    """
-    The query root of this schema
-    """
-    type Query {
-      """
-      Find a post by ID
-      """
-      post(input: [PostInput!]!, test: TestEnum!): Post
-    }
-
-    enum TestEnum {
-      TEST1
-      TEST2
-      TEST3
-    }|)
-  end
-
-  let(:query_string) do
-    %|
-      query GetPost2($input: [PostInput!]!) {
-        post(input: $input, test: TEST1) {
-          title
-
-          myId: id
-        }
-      }
-    |
-  end
-
-  it 'should return all used fields, input type and enum values' do
+  subject(:used_fields) do
     query = GraphQL::Query.new(schema, query_string)
-
     analyzer = GraphQL::Hive::Analyzer.new(query)
     visitor = GraphQL::Analysis::AST::Visitor.new(
       query: query,
@@ -60,8 +12,168 @@ RSpec.describe 'GraphQL::Hive::Analyzer' do
     )
 
     visitor.visit
+    analyzer.used_fields.to_a
+  end
 
-    expect(analyzer.used_fields.to_a).to eq(['Query.post.input', 'PostInput', 'PostInput.id', 'Query.post.test',
-                                             'TestEnum.TEST1', 'Post', 'Post.title', 'Post.id', 'Query', 'Query.post'])
+  let(:schema) do
+    GraphQL::Schema.from_definition(%|
+      type Query {
+        project(selector: ProjectSelectorInput!): Project
+        projectsByType(type: ProjectType!): [Project!]!
+        projects(filter: FilterInput): [Project!]!
+      }
+
+      type Mutation {
+        deleteProject(selector: ProjectSelectorInput!): DeleteProjectPayload!
+      }
+
+      input ProjectSelectorInput {
+        organization: ID!
+        project: ID!
+      }
+
+      input FilterInput {
+        type: ProjectType
+        pagination: PaginationInput
+        order: [ProjectOrderByInput!]
+      }
+
+      input PaginationInput {
+        limit: Int
+        offset: Int
+      }
+
+      input ProjectOrderByInput {
+        field: String!
+        direction: OrderDirection
+      }
+
+      enum OrderDirection {
+        ASC
+        DESC
+      }
+
+      type ProjectSelector {
+        organization: ID!
+        project: ID!
+      }
+
+      type DeleteProjectPayload {
+        selector: ProjectSelector!
+        deletedProject: Project!
+      }
+
+      type Project {
+        id: ID!
+        cleanId: ID!
+        name: String!
+        type: ProjectType!
+        buildUrl: String
+        validationUrl: String
+      }
+
+      enum ProjectType {
+        FEDERATION
+        STITCHING
+        SINGLE
+        CUSTOM
+      }
+    |)
+  end
+
+  let(:query_string) do
+    %|
+      mutation deleteProject($selector: ProjectSelectorInput!) {
+        deleteProject(selector: $selector) {
+          selector {
+            organization
+            project
+          }
+
+          deletedProject {
+            id
+            cleanId
+            name
+            type
+          }
+        }
+      }
+    |
+  end
+
+  it 'collects used fields' do
+    puts used_fields
+    expect(used_fields).to include(
+      'DeleteProjectPayload',
+      'DeleteProjectPayload.selector',
+      'Mutation',
+      'Mutation.deleteProject',
+      'Mutation.deleteProject.selector',
+      'Project',
+      'Project.cleanId',
+      'Project.id',
+      'Project.name',
+      'Project.type',
+      'ProjectSelector',
+      'ProjectSelector.organization',
+      'ProjectSelector.project'
+    )
+    expect(used_fields).not_to include(
+      'Project.buildUrl',
+      'Project.validationUrl'
+    )
+  end
+
+  it 'collects used input object fields' do
+    expect(used_fields).to include(
+      'ProjectSelectorInput',
+      'ProjectSelectorInput.organization',
+      'ProjectSelectorInput.project'
+    )
+  end
+
+  context 'with enum values in arguments' do
+    let(:query_string) do
+      %|
+        query getProjects {
+          projectsByType(type: FEDERATION) {
+            id
+          }
+        }
+      |
+    end
+
+    it 'collects used enumn values' do
+      puts used_fields
+      expect(used_fields).to include(
+        'ProjectType.FEDERATION'
+      )
+    end
+  end
+
+  context 'with nested input object argument' do
+    let(:query_string) do
+      %|
+        query getProjects($limit: Int!, $type: ProjectType!) {
+          projects(filter: { pagination: { limit: $limit }, type: $type }) {
+            id
+          }
+        }
+      |
+    end
+
+    it 'collects fields of all input objects' do
+      expect(used_fields).to include(
+        'PaginationInput',
+        'PaginationInput.limit',
+        'PaginationInput.offset',
+        'ProjectType.type',
+        'Query.projects.filter',
+        'FilterInput',
+        'FilterInput.type',
+        'FilterInput.pagination',
+        'FilterInput.order'
+      )
+    end
   end
 end


### PR DESCRIPTION
fixes https://github.com/charlypoly/graphql-ruby-hive/issues/12

### What changed
- inspect `node.value` during `on_enter_argument`
  - if its a variable, add all values (all fields if an input object or all possibilities of an enum) as used
  - if its a list, iterate and add the values / fields of input objects
  - if its an explicit value, iterate through the given values and mark the input object fields, or given enum value, as used