### PR TITLE
fix: pass "null" for error path in report when it does not exist for an error

### DIFF
--- a/lib/graphql-hive/usage_reporter.rb
+++ b/lib/graphql-hive/usage_reporter.rb
@@ -147,7 +147,7 @@ module GraphQL
           errors = result.to_h.fetch('errors', [])
           errors.each do |error|
             acc[:errorsTotal] += 1
-            acc[:errors] << { message: error['message'], path: error['path'].join('.') }
+            acc[:errors] << { message: error['message'], path: error['path']&.join('.') }
           end
         end
         acc


### PR DESCRIPTION
> If an error can be associated to a particular field in the GraphQL result, it must contain an entry with the key path that details the path of the response field which experienced the error.
> [spec](https://spec.graphql.org/June2018/#sec-Errors)

Sometimes GraphQL errors don't have a particular path associated with them.  In these cases, `graphql-ruby-hive` throws an error when trying to join the path elements together.

> ```
> [...]/ruby/2.7.7/lib/ruby/gems/2.7.0/gems/graphql-hive-0.3.0/lib/graphql-hive/usage_reporter.rb:150:in `block (2 levels) in errors_from_results': undefined method `join' for nil:NilClass (NoMethodError)
> ```

In these cases, `null` should be passed.  This will match the benaviour of the JS client ([code](https://github.com/kamilkisiela/graphql-hive/blob/ca8cf43480940c42fb83ac6bf1d7e63bdb91ae81/packages/libraries/client/src/internal/usage.ts#L170))