### PR TITLE
fix: ensure errors from operations buffer flushing thread log to the configured logger

### DIFF
--- a/lib/graphql-hive/usage_reporter.rb
+++ b/lib/graphql-hive/usage_reporter.rb
@@ -69,6 +69,11 @@ module GraphQL
             @options[:logger].debug('shuting down with buffer, sending!')
             process_operations(buffer)
           end
+        rescue Exception => e
+          @options[:logger].error("GraphQL Hive usage collection thread terminating")
+          @options[:logger].error(e)
+
+          raise e
         end
       end
 

--- a/lib/graphql-hive/usage_reporter.rb
+++ b/lib/graphql-hive/usage_reporter.rb
@@ -70,7 +70,9 @@ module GraphQL
             process_operations(buffer)
           end
         rescue Exception => e
-          @options[:logger].error("GraphQL Hive usage collection thread terminating")
+          # ensure configured logger receives exception as well in setups where STDERR might not be
+          # monitored.
+          @options[:logger].error('GraphQL Hive usage collection thread terminating')
           @options[:logger].error(e)
 
           raise e

--- a/lib/graphql-hive/usage_reporter.rb
+++ b/lib/graphql-hive/usage_reporter.rb
@@ -69,7 +69,7 @@ module GraphQL
             @options[:logger].debug('shuting down with buffer, sending!')
             process_operations(buffer)
           end
-        rescue Exception => e
+        rescue StandardError => e
           # ensure configured logger receives exception as well in setups where STDERR might not be
           # monitored.
           @options[:logger].error('GraphQL Hive usage collection thread terminating')


### PR DESCRIPTION
By default, unhandled exceptions raised in ruby threads:
- do not re-raise the exception in the main thread (unless `Thread.abort_on_exception` is set ([docs](https://ruby-doc.org/core-2.5.2/Thread.html#method-c-abort_on_exception)))
- _do_ print the error to $STDERR (unless `Thread.report_on_error` is explicitly disabled ([docs](https://ruby-doc.org/core-2.5.0/Thread.html#method-c-report_on_exception)))

At our org, we ship our application logs using logstash, i.e. instead of scraping $STDOUT/$STDERR we have our logger configured to write logs via TCP to an address on the network our containers run on.

This PR adds a block to ensure unhandled exceptions thrown in the thread that flushes the operations buffer logs go through the configured logger before terminating the thread.

---

Semi-related: when the thread that flushes operations dies due to an unhandled exception, there is no existing mechanism to restart the thread.  This means the other threads executing requests and adding more queries into the `@queue` will continue forever, i.e. the queue will grow until... :bomb:?