### PR TITLE
fix: sort inline fragments by their type name

### DIFF
--- a/lib/graphql-hive/printer.rb
+++ b/lib/graphql-hive/printer.rb
@@ -33,7 +33,13 @@ module GraphQL
       end
 
       def print_selections(selections, indent: '')
-        super(selections.sort_by(&:name), indent: indent)
+        sorted_nodes = selections.sort_by do |s|
+          next s.name if s.respond_to?(:name)
+          next s.type.name if s.respond_to?(:type)
+
+          raise "don't know how to sort selection node: #{s.inspect}"
+        end
+        super(sorted_nodes, indent: indent)
       end
 
       def print_directive(directive)


### PR DESCRIPTION
inline fragment nodes do not have a `name` method, causing the `GraphQL::Hive::Printer` to raise an error when trying to sort a list of selection nodes that contain an inline fragment.

```
NoMethodError:
  undefined method `name' for #<GraphQL::Language::Nodes::InlineFragment:0x00000001048e5530 @line=5, @col=11, @filename=nil, @type=#<GraphQL::Language::Nodes::TypeName:0x00000001048e5bc0 @filename=nil, @name="HasAuthor">, @selections=[#<GraphQL::Language::Nodes::Field:0x00000001048e5698 @line=6, @col=13, @filename=nil, @name="author", @arguments=[], @directives=[], @selections=[#<GraphQL::Language::Nodes::Field:0x00000001048e5878 @line=7, @col=15, @filename=nil, @name="name", @arguments=[], @directives=[], @selections=[], @alias=nil>], @alias=nil>], @directives=[]>

          super(selections.sort_by(&:name), indent: indent)
                          ^^^^^^^^
# ./lib/graphql-hive/printer.rb:36:in `each'
# ./lib/graphql-hive/printer.rb:36:in `sort_by'
# ./lib/graphql-hive/printer.rb:36:in `print_selections'
# ./lib/graphql-hive/printer.rb:26:in `print_field'
```

```ruby
<GraphQL::Language::Nodes::InlineFragment:0x0000000106e0b828
 @col=11,
 @directives=[],
 @filename=nil,
 @line=10,
 @selections=
  [#<GraphQL::Language::Nodes::Field:0x0000000106e0b968
    @alias=nil,
    @arguments=[],
    @col=13,
    @directives=[],
    @filename=nil,
    @line=11,
    @name="publisher",
    @selections=[#<GraphQL::Language::Nodes::Field:0x0000000106e0baa8 @alias=nil, @arguments=[], @col=15, @directives=[], @filename=nil, @line=12, @name="name", @selections=[]>]>],
 @type=#<GraphQL::Language::Nodes::TypeName:0x0000000106e0bc60 @filename=nil, @name="HasPublisher">>
```