### PR TITLE
Update GraphQL gem version to latest (also add debug Gem)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     graphql-hive (0.3.3)
-      graphql (~> 2.0.9)
+      graphql (~> 2.2.5)
 
 GEM
   remote: https://rubygems.org/
@@ -12,7 +12,8 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.5.0)
-    graphql (2.0.27)
+    graphql (2.2.5)
+      racc (~> 1.4)
     io-console (0.7.2)
     irb (1.11.1)
       rdoc
@@ -22,6 +23,7 @@ GEM
       ast (~> 2.4.1)
     psych (5.1.2)
       stringio
+    racc (1.7.3)
     rainbow (3.1.1)
     rake (10.5.0)
     rdoc (6.6.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,27 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    debug (1.9.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.5.0)
-    graphql (2.0.21)
+    graphql (2.0.27)
+    io-console (0.7.2)
+    irb (1.11.1)
+      rdoc
+      reline (>= 0.4.2)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    psych (5.1.2)
+      stringio
     rainbow (3.1.1)
     rake (10.5.0)
+    rdoc (6.6.2)
+      psych (>= 4.0.0)
     regexp_parser (2.5.0)
+    reline (0.4.2)
+      io-console (~> 0.5)
     rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
@@ -42,6 +55,7 @@ GEM
     rubocop-ast (1.18.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
+    stringio (3.1.0)
     unicode-display_width (2.1.0)
 
 PLATFORMS
@@ -49,6 +63,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.17)
+  debug
   graphql-hive!
   rake (~> 10.0)
   rspec (~> 3.0)

--- a/graphql-hive.gemspec
+++ b/graphql-hive.gemspec
@@ -24,9 +24,11 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
   end
 
+  # spec.add_dependency 'graphql', '~> 2.2.5'
   spec.add_dependency 'graphql', '~> 2.0.9'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'debug'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.30'

--- a/graphql-hive.gemspec
+++ b/graphql-hive.gemspec
@@ -24,8 +24,7 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
   end
 
-  # spec.add_dependency 'graphql', '~> 2.2.5'
-  spec.add_dependency 'graphql', '~> 2.0.9'
+  spec.add_dependency 'graphql', '~> 2.2.5'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'debug'

--- a/lib/graphql-hive/printer.rb
+++ b/lib/graphql-hive/printer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'debug'
+
 module GraphQL
   class Hive < GraphQL::Tracing::PlatformTracing
     # - removes literals
@@ -29,10 +31,14 @@ module GraphQL
       # rubocop:enable Style/RedundantInterpolation
 
       def print_directives(directives)
+        return '' if directives.empty?
+
         super(directives.sort_by(&:name))
       end
 
       def print_selections(selections, indent: '')
+        return '' if selections.empty?
+
         sorted_nodes = selections.sort_by do |s|
           next s.name if s.respond_to?(:name)
           next s.type.name if s.respond_to?(:type)

--- a/lib/graphql-hive/printer.rb
+++ b/lib/graphql-hive/printer.rb
@@ -33,14 +33,10 @@ module GraphQL
       end
 
       def print_directives(directives)
-        return '' if directives.empty?
-
         super(directives.sort_by(&:name))
       end
 
       def print_selections(selections, indent: '')
-        return '' if selections.empty?
-
         sorted_nodes = selections.sort_by do |s|
           next s.name if s.respond_to?(:name)
           next s.type.name if s.respond_to?(:type)

--- a/lib/graphql-hive/printer.rb
+++ b/lib/graphql-hive/printer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'debug'
-
 module GraphQL
   class Hive < GraphQL::Tracing::PlatformTracing
     # - removes literals
@@ -11,24 +9,28 @@ module GraphQL
       def print_node(node, indent: '')
         case node
         when Float, Integer
-          '0'
+          print_string('0')
         when String
-          ''
+          print_string('')
         else
           super(node, indent: indent)
         end
       end
 
-      # rubocop:disable Style/RedundantInterpolation
       def print_field(field, indent: '')
-        out = "#{indent}".dup
-        out << "#{field.name}"
-        out << "(#{field.arguments.sort_by(&:name).map { |a| print_argument(a) }.join(', ')})" if field.arguments.any?
-        out << print_directives(field.directives)
-        out << print_selections(field.selections, indent: indent)
-        out
+        print_string(indent)
+        print_string(field.name)
+        if field.arguments.any?
+          print_string('(')
+          field.arguments.sort_by(&:name).each_with_index do |a, i|
+            print_argument(a)
+            print_string(', ') if i < field.arguments.size - 1
+          end
+          print_string(')')
+        end
+        print_directives(field.directives)
+        print_selections(field.selections, indent: indent)
       end
-      # rubocop:enable Style/RedundantInterpolation
 
       def print_directives(directives)
         return '' if directives.empty?
@@ -49,28 +51,38 @@ module GraphQL
       end
 
       def print_directive(directive)
-        out = "@#{directive.name}".dup
+        print_string('@')
+        print_string(directive.name)
 
         if directive.arguments.any?
-          out << "(#{directive.arguments.sort_by(&:name).map { |a| print_argument(a) }.join(', ')})"
+          print_string('(')
+          directive.arguments.sort_by(&:name).each_with_index do |a, i|
+            print_argument(a)
+            print_string(', ') if i < directive.arguments.size - 1
+          end
+          print_string(')')
         end
-
-        out
       end
 
       def print_operation_definition(operation_definition, indent: '')
-        out = "#{indent}#{operation_definition.operation_type}".dup
-        out << " #{operation_definition.name}" if operation_definition.name
-
-        # rubocop:disable Layout/LineLength
-        if operation_definition.variables.any?
-          out << "(#{operation_definition.variables.sort_by(&:name).map { |v| print_variable_definition(v) }.join(', ')})"
+        print_string(indent)
+        print_string(operation_definition.operation_type)
+        if operation_definition.name
+          print_string(' ')
+          print_string(operation_definition.name)
         end
-        # rubocop:enable Layout/LineLength
 
-        out << print_directives(operation_definition.directives)
-        out << print_selections(operation_definition.selections, indent: indent)
-        out
+        if operation_definition.variables.any?
+          print_string('(')
+          operation_definition.variables.sort_by(&:name).each_with_index do |v, i|
+            print_variable_definition(v)
+            print_string(', ') if i < operation_definition.variables.size - 1
+          end
+          print_string(')')
+        end
+
+        print_directives(operation_definition.directives)
+        print_selections(operation_definition.selections, indent: indent)
       end
     end
   end


### PR DESCRIPTION
We use this Gem + GQL Hive for metrics on our GQL API. We are currently trying to update to the latest version of the Ruby GQL Gem and this is our blocker. 

All I did here is bump the GraphQL Gem to the latest and fix the tests. In the process I also added the Debug Gem to help debug the broken specs (there were two that needed to be fixed).

Fixes boiled down to just updating the `GraphQL::Hive::Printer` to use the `print_string` method instead of returning strings to be compatible with the latest version of `GraphQL::Language::Printer`. I just copied the newest versions of these methods from the graphql gems codebase and then made sure the same alterations to the printer were still respected (remove literals/aliases and sort nodes)